### PR TITLE
Pull based deployments

### DIFF
--- a/packs/leap-node10/.dockerignore
+++ b/packs/leap-node10/.dockerignore
@@ -1,5 +1,6 @@
 draft.toml
 charts/
+node_modules/
 NOTICE
 LICENSE
 README.md

--- a/packs/leap-node10/DEPLOY.md
+++ b/packs/leap-node10/DEPLOY.md
@@ -1,0 +1,23 @@
+
+# Deploy to Production
+Applications are deployed to the serverless framework Knative to manage zero to infinity autoscaling in a controlled environment.
+You can disable Knative and use regular helm deployments if you choose by setting `knativeDeploy` to `false` in `charts/<your-repo-name>/values.yaml`.
+The only drawback of using Knative with the current architecture is that it requires manual deployments. In either case the jenkins CI and previews will still be automated.
+
+## Deploy
+### Manual
+If you are using non-knative deployments you will only need to do a manual deployment after merging in changes that modify the contents of `charts/<your-repo-name>/`. Otherwise if you are using Knative you will have to run this redeployment for every release
+1. Wait for the jenkins x pipeline to finish (check logs with `jx get build log -f <your-repo-name>`).
+2. Connect to the kubernetes cluster you want to deploy to
+3. `helm repo update`
+4. `helm update -n <your-namespace> <your-service-name> leap/<your-repo-name>`
+
+#### Substitute these steps for initial deployment
+3. `helm repo add leap https://chartmuseum-jx.123leap.ca`
+4. `helm install -n <your-namespace> <your-service-name> leap/<your-repo-name>`
+
+### Rollback
+#### Non Knative
+The docker image with the `latest` tag is pulled into prod on demand. Therefore to do a rollback you just have to update the `latest` tag in GCR to the version you want to rollback to. The next deployment will automatically update the `latest` tag so no additional work should be needed. If you did a manual deployment of the helm chart you will also have to run the rollback outlined in the Knative section below.
+#### Knative
+To revert you have to do a `helm rollback` with the chart version you want to rollback.

--- a/packs/leap-node10/Dockerfile
+++ b/packs/leap-node10/Dockerfile
@@ -1,6 +1,16 @@
 FROM node:10-slim
+
+ENV NODE_ENV=production
 ENV PORT 8080
+
 EXPOSE 8080
+
 WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app
+COPY yarn.lock /usr/src/app
+RUN yarn install --production
+
 COPY . .
-CMD ["npm", "start"]
+
+CMD ["yarn", "start"]

--- a/packs/leap-node10/charts/templates/deployment.yaml
+++ b/packs/leap-node10/charts/templates/deployment.yaml
@@ -21,8 +21,8 @@ spec:
     spec:
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ .Values.image.repository }}"
+        imagePullPolicy: Always
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}

--- a/packs/leap-node10/charts/templates/ksvc.yaml
+++ b/packs/leap-node10/charts/templates/ksvc.yaml
@@ -15,8 +15,8 @@ spec:
       revisionTemplate:
         spec:
           container:
-            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            image: "{{ .Values.image.repository }}"
+            imagePullPolicy: Always
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}

--- a/packs/leap-node10/charts/templates/ksvc.yaml
+++ b/packs/leap-node10/charts/templates/ksvc.yaml
@@ -15,8 +15,8 @@ spec:
       revisionTemplate:
         spec:
           container:
-            image: "{{ .Values.image.repository }}"
-            imagePullPolicy: Always
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
             env:
 {{- range $pkey, $pval := .Values.env }}
             - name: {{ $pkey }}

--- a/packs/leap-node10/charts/values.yaml
+++ b/packs/leap-node10/charts/values.yaml
@@ -11,7 +11,7 @@ image:
 env:
 
 # enable this flag to use knative serve to deploy the app
-knativeDeploy: false
+knativeDeploy: true
 
 service:
   name: REPLACE_ME_APP_NAME

--- a/packs/leap-node10/pipeline.yaml
+++ b/packs/leap-node10/pipeline.yaml
@@ -1,6 +1,16 @@
 extends:
   import: classic
   file: javascript/pipeline.yaml
+pipelineConfig:
+  pipelines:
+    overrides:
+    - name: npm-install
+      stage: build
+      steps:
+      - command: yarn install
+        dir: /workspace/source
+        image: nodejs
+        name: yarn-install
 pipelines:
   pullRequest:
     build:
@@ -36,20 +46,5 @@ pipelines:
         - comment: release the helm chart
           sh: jx step helm release
           name: helm-release
-        - name: deploy-to-cloud-run
-          command: gcloud
-          args:
-            - --quiet
-            - --no-user-output-enabled
-            - components
-            - update
-            - " && "
-            - gcloud
-            - --quiet
-            - beta
-            - run
-            - deploy
-            - $APP_NAME
-            - --image=$DOCKER_REGISTRY/$(gcloud config get-value project)/$APP_NAME:$PREVIEW_VERSION
-            - --region=us-central1
-            - --platform=managed
+        - command: gcloud container images add-tag $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION) $DOCKER_REGISTRY/$ORG/$APP_NAME:latest
+          name: update-latest-tag

--- a/packs/leap-node10/pipeline.yaml
+++ b/packs/leap-node10/pipeline.yaml
@@ -4,6 +4,7 @@ extends:
 pipelineConfig:
   pipelines:
     overrides:
+    # Override npm with yarn
     - name: npm-install
       stage: build
       steps:
@@ -11,6 +12,13 @@ pipelineConfig:
         dir: /workspace/source
         image: nodejs
         name: yarn-install
+    - name: npm-test
+      stage: build
+      steps:
+      - command: CI=true DISPLAY=:99 yarn test
+        dir: /workspace/source
+        image: nodejs
+        name: yarn-test
 pipelines:
   pullRequest:
     build:

--- a/packs/leap-node10/pipeline.yaml
+++ b/packs/leap-node10/pipeline.yaml
@@ -41,7 +41,7 @@ pipelines:
       steps:
       - dir: ./charts/REPLACE_ME_APP_NAME
         steps:
-        - sh: jx step changelog --batch-mode --version v\$(cat ../../VERSION)
+        - sh: jx step changelog --batch-mode --generate-yaml=false --version v\$(cat ../../VERSION)
           name: changelog
         - comment: release the helm chart
           sh: jx step helm release

--- a/packs/leap-python-server/charts/templates/deployment.yaml
+++ b/packs/leap-python-server/charts/templates/deployment.yaml
@@ -21,8 +21,8 @@ spec:
     spec:
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ .Values.image.repository }}"
+        imagePullPolicy: Always
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}

--- a/packs/leap-python-server/charts/values.yaml
+++ b/packs/leap-python-server/charts/values.yaml
@@ -11,7 +11,7 @@ image:
 env:
 
 # enable this flag to use knative serve to deploy the app
-knativeDeploy: false
+knativeDeploy: true
 
 service:
   name: REPLACE_ME_APP_NAME

--- a/packs/leap-python-server/pipeline.yaml
+++ b/packs/leap-python-server/pipeline.yaml
@@ -31,25 +31,10 @@ pipelines:
       steps:
       - dir: ./charts/REPLACE_ME_APP_NAME
         steps:
-        - sh: jx step changelog --version v\$(cat ../../VERSION)
+        - sh: jx step changelog --generate-yaml=false --version v\$(cat ../../VERSION)
           name: changelog
         - comment: release the helm chart
           sh: jx step helm release
           name: helm-release
-        - name: deploy-to-cloud-run
-          command: gcloud
-          args:
-            - --quiet
-            - components
-            - update
-            - " && "
-            - gcloud
-            - --quiet
-            - --no-user-output-enabled
-            - beta
-            - run
-            - deploy
-            - $APP_NAME
-            - --image=$DOCKER_REGISTRY/$(gcloud config get-value project)/$APP_NAME:$PREVIEW_VERSION
-            - --region=us-central1
-            - --platform=managed
+        - command: gcloud container images add-tag $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION) $DOCKER_REGISTRY/$ORG/$APP_NAME:latest
+          name: update-latest-tag

--- a/packs/leap-python/charts/templates/deployment.yaml
+++ b/packs/leap-python/charts/templates/deployment.yaml
@@ -21,8 +21,8 @@ spec:
     spec:
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ .Values.image.repository }}"
+        imagePullPolicy: Always
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}

--- a/packs/leap-python/charts/values.yaml
+++ b/packs/leap-python/charts/values.yaml
@@ -11,7 +11,7 @@ image:
 env:
 
 # enable this flag to use knative serve to deploy the app
-knativeDeploy: false
+knativeDeploy: true
 
 service:
   name: REPLACE_ME_APP_NAME

--- a/packs/leap-python/pipeline.yaml
+++ b/packs/leap-python/pipeline.yaml
@@ -31,25 +31,10 @@ pipelines:
       steps:
       - dir: ./charts/REPLACE_ME_APP_NAME
         steps:
-        - sh: jx step changelog --version v\$(cat ../../VERSION)
+        - sh: jx step changelog --generate-yaml=false --version v\$(cat ../../VERSION)
           name: changelog
         - comment: release the helm chart
           sh: jx step helm release
           name: helm-release
-        - name: deploy-to-cloud-run
-          command: gcloud
-          args:
-            - --quiet
-            - components
-            - update
-            - " && "
-            - gcloud
-            - --quiet
-            - --no-user-output-enabled
-            - beta
-            - run
-            - deploy
-            - $APP_NAME
-            - --image=$DOCKER_REGISTRY/$(gcloud config get-value project)/$APP_NAME:$PREVIEW_VERSION
-            - --region=us-central1
-            - --platform=managed
+        - command: gcloud container images add-tag $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION) $DOCKER_REGISTRY/$ORG/$APP_NAME:latest
+          name: update-latest-tag

--- a/packs/leap-react-ts/charts/templates/deployment.yaml
+++ b/packs/leap-react-ts/charts/templates/deployment.yaml
@@ -21,8 +21,8 @@ spec:
     spec:
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ .Values.image.repository }}"
+        imagePullPolicy: Always
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}

--- a/packs/leap-react-ts/charts/values.yaml
+++ b/packs/leap-react-ts/charts/values.yaml
@@ -11,7 +11,7 @@ image:
 env:
 
 # enable this flag to use knative serve to deploy the app
-knativeDeploy: false
+knativeDeploy: true
 
 service:
   name: REPLACE_ME_APP_NAME

--- a/packs/leap-typescript/charts/templates/deployment.yaml
+++ b/packs/leap-typescript/charts/templates/deployment.yaml
@@ -21,8 +21,8 @@ spec:
     spec:
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ .Values.image.repository }}"
+        imagePullPolicy: Always
         env:
 {{- range $pkey, $pval := .Values.env }}
         - name: {{ $pkey }}

--- a/packs/leap-typescript/charts/values.yaml
+++ b/packs/leap-typescript/charts/values.yaml
@@ -11,7 +11,7 @@ image:
 env:
 
 # enable this flag to use knative serve to deploy the app
-knativeDeploy: false
+knativeDeploy: true
 
 service:
   name: REPLACE_ME_APP_NAME


### PR DESCRIPTION
 - Sets the `pullPolicy` to `Always`
 - Set deployed image tag to `latest`
 - Replace npm with yarn
 - Remove cloud run deployments
 - Set Knative as default deployment mechanism